### PR TITLE
 Encoutering ECONNRESET when fetching probe data from ripe

### DIFF
--- a/probes.js
+++ b/probes.js
@@ -2,6 +2,9 @@ const axios = require('axios');
 const neo4j = require('neo4j-driver');
 const driver = neo4j.driver("bolt://localhost:7687", neo4j.auth.basic("neo4j", "eli@sol2")); //Replace with your connection details
 
+// TODO:
+// fix the error: Failed to fetch probe list: AxiosError: read ECONNRESET
+
 // Get all Probes
 async function fetchAfricanProbes(country_code) {
     // Define the API endpoint


### PR DESCRIPTION
The `ECONNRESET` error indicates that the TCP connection was abruptly closed by the server (or a proxy in between). This could happen for a number of reasons, and the error isn't always easy to debug because it's so generic.

Here are some potential causes and corresponding solutions:

1. **The server is too busy or is rate-limiting:** Some servers limit the number of connections or requests from a single IP address in a given time period to prevent abuse. To resolve this, you could try adding a delay between requests or reducing the number of requests. If you're making a lot of requests, you may need to find a way to make fewer requests or spread them out over time.

2. **The server or proxy has a timeout that's being reached:** This could be due to network latency, or your request taking too long to process. You can try increasing the timeout on your axios request to see if that solves the issue. Here's how to do that:
