### PR TITLE
pulling from ID from dabase: Deprecated hardcoded probe IDs

### DIFF
--- a/measurements.js
+++ b/measurements.js
@@ -2,14 +2,41 @@ const axios = require('axios');
 const neo4j = require('neo4j-driver');
 const driver = neo4j.driver("bolt://localhost:7687", neo4j.auth.basic("neo4j", "eli@sol2"));
 
-// Section : simple traceroute request to ripe atlas
-// from one probe to destination ip
+async function createMeasurementFromDatabase(numberOfProbes, countryCode, probeIDs) {
+    console.log("Measurement initiated!");
 
-async function createMeasurement(probes, target) {
-    console.log("measurement initiated!");
+    // Create a session to fetch probe data from the database
+    const session = driver.session({database: 'neo4j'});
 
+    // Initialize an array to store the fetched probe IDs
+    let probes = [];
+
+    if(probeIDs) {  // if specific probeIDs are given
+        probes = probeIDs;
+    } else {
+        let result;
+        if(countryCode) {  // if a countryCode is given
+            result = await session.run(
+                `MATCH (p:Probe {country: $countryCode}) RETURN p.id AS id LIMIT $limit`,
+                {countryCode: countryCode, limit: neo4j.int(numberOfProbes)}
+            );
+        } else {  // if no countryCode is given
+            result = await session.run(
+                `MATCH (p:Probe) RETURN p.id AS id LIMIT $limit`,
+                {limit: neo4j.int(numberOfProbes)}
+            );
+        }
+        // Extract the probe IDs from the result and add them to the probes array
+        result.records.forEach(record => probes.push(parseInt(record.get('id'))));
+    }
+
+    // Define the target IP
+    const target = '196.252.138.15';
+
+    // Define the API key
     const API_KEY = '216fafa6-2a2d-438a-9bb3-7309aa0acf59';
 
+    // Define the measurement data
     const data = {
         "definitions": [
             {
@@ -30,6 +57,7 @@ async function createMeasurement(probes, target) {
         ]
     };
 
+    // Define the request configuration
     const config = {
         method: 'post',
         url: 'https://atlas.ripe.net/api/v2/measurements/',
@@ -47,9 +75,6 @@ async function createMeasurement(probes, target) {
         // Extract the measurement id from the response
         let measurementId = response.data.measurements[0];
 
-        // Create a session to write measurement id to the database
-        const session = driver.session({database: 'neo4j'});
-
         // Write to the database
         await session.run(
             `CREATE (m:Measurement {measurementId: $measurementId, isRead: false}) RETURN m`,
@@ -57,64 +82,19 @@ async function createMeasurement(probes, target) {
         );
 
         console.log("Write complete");
-
+    } catch (error) {
+        console.error(error);
+    } finally {
         session.close();
-
         console.log("Session closed");
-
-    } catch (error) {
-        console.error(error);
-      } finally {
-      driver.close();  // Close the driver connection
-      console.log("Driver closed");
-  }
-}
-
-module.exports.createMeasurement = createMeasurement;
-
-async function getMeasurementResults(measurementId) {
-    // Replace this with your actual RIPE Atlas API key
-    console.log("fetch initiated!");
-    const API_KEY = '216fafa6-2a2d-438a-9bb3-7309aa0acf59';
-
-    // Array to store results
-    const results = [];
-
-    try {
-
-        const config = {
-            method: 'get',
-            url: `https://atlas.ripe.net/api/v2/measurements/${measurementId}/results/`,
-            headers: {
-                'Authorization': `Key ${API_KEY}`
-            }
-        };
-
-        const response = await axios(config);
-        // console.log(`Results for measurement ID ${measurementId}:`);
-        // console.log(JSON.stringify(response.data));
-
-        // Add results to array
-        return response.data;
-
-    } catch (error) {
-        console.error(error);
-        return null;
+        driver.close();  // Close the driver connection
+        console.log("Driver closed");
     }
-
 }
 
-// export getMeasurementResults Function
-module.exports = getMeasurementResults;
+module.exports.createMeasurementFromDatabase = createMeasurementFromDatabase;
 
-createMeasurement([4153, 1002544], '196.252.138.15')
-  .then(() => console.log("terminate!"))
-  .catch(err => console.error(err));
-
-// Test fetch measurement results function
-// getMeasurementResults(55167870)
-// .then(results => {
-//     // Use the results here
-//     console.log(results);
-// })
-// .catch(err => console.error(err));
+// Example usage:
+createMeasurementFromDatabase(5, 'ZA', null)
+    .then(() => console.log("Terminate!"))
+    .catch(err => console.error(err));


### PR DESCRIPTION
The function `createMeasurementFromDatabase()` initiates a network measurement from a selection of probes stored in your Neo4j database and then sends the measurements to the target specified in the function `createMeasurement()`. The parameters passed to the `createMeasurementFromDatabase()` function control the selection of the probes as follows:

1. The first argument (`5` in this case) is the total number of probes you want to use for your measurement. 

2. The second argument (`'ZA'` in this case) is the country code. The function will select probes that are located in this country. If this argument is `null`, the function will not filter the probes by country.

3. The third argument can be a list of specific probe IDs you want to use. If this argument is `null`, the function will select probes randomly (or based on the country code if it's specified).

The function works as follows:

1. It first establishes a session with the Neo4j database.

2. Then it runs a Cypher query to retrieve the probes based on the parameters passed. The Cypher query is constructed dynamically based on whether the country code and specific probe IDs are provided.

3. It transforms the results from the database query into an array of probe IDs.

4. These probe IDs are then passed to the `createMeasurement()` function along with the target (hardcoded as `'196.252.138.15'` in the function definition).

5. The `createMeasurement()` function sends a request to the RIPE Atlas API to initiate a traceroute measurement from the selected probes to the target.

6. The response from the API, which contains the measurement ID, is then stored back in the Neo4j database for future reference.

Finally, the Promise returned by `createMeasurementFromDatabase()` is handled. If the function completes without errors, "Terminate!" is logged to the console. If an error occurs, it is caught and logged to the console.