### PR TITLE
maxmind geolocation with an ip2location fallback

### DIFF
--- a/geoInfo.js
+++ b/geoInfo.js
@@ -8,6 +8,8 @@ const driver = neo4j.driver("bolt://localhost:7687", neo4j.auth.basic("neo4j", "
 // Define the session
 const session = driver.session();
 
+// import getGeoInfo from ip2location script
+const { getGeoInfo } = require('./ip2locationTest.js');
 
 // IP adress look-up
 async function geoLookup(ipAddress) {
@@ -41,7 +43,9 @@ async function geoLookup(ipAddress) {
         return result;
     } catch (err) {
         console.log(`No geolocation data found for IP: ${ipAddress}. Error: ${err}`);
-        return null;
+        // use getGeoInfo function from ip2location script
+        return getGeoInfo(ipAddress);
+        // return null;
     }
 }
 


### PR DESCRIPTION
the script updates the Router nodes with geoinformation. It uses maxmind geolocation database by default but queries ip2location database when the maxmind database fails. 